### PR TITLE
WIP: Generic prometheus + node exporter + grafana for monitoring infra

### DIFF
--- a/grafana/generic/setup-grafana/README.md
+++ b/grafana/generic/setup-grafana/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/grafana/generic/setup-grafana/README.md
+++ b/grafana/generic/setup-grafana/README.md
@@ -1,38 +1,57 @@
-Role Name
+setup-node-exporter
 =========
 
-A brief description of the role goes here.
+This role will instantiate a grafana container on targeted hosts.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+Docker must be available and running on the targeted hosts.
 
 Role Variables
 --------------
+Default values of variables:
+```
+---
+grafana_image: 'grafana/grafana'
+grafana_image_version: 'latest'
+grafana_port: '3000'
+grafana_password: 'super_secure_password'
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+prometheus_port: '9090'
+
+provision_state: "started"
+
+```
+`grafana_image` - The node exporter image to deploy.
+`grafana_image_version` - The image tag to deploy.
+`grafana_port` - The port to expose on the target hosts.
+`grafana_password` - The admin password to set for Grafana.
+`prometheus_port` - The target port on the prometheus host to pull data.
+`provision_state` - Options: [absent, killed, present, reloaded, restarted, **started** (default), stopped]
+
 
 Dependencies
 ------------
-
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+```
+python >= 2.6
+docker-py >= 0.3.0
+The docker server >= 0.10.0
+```
 
 Example Playbook
 ----------------
-
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+```
+- name: Setup grafana
+  hosts: grafana
+  become: True
+  vars:
+    provision_state: "started"
+  roles:
+    - grafana/generic/setup-grafana
+```
 
 License
 -------
 
 BSD
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/grafana/generic/setup-grafana/defaults/main.yml
+++ b/grafana/generic/setup-grafana/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+grafana_image: 'grafana/grafana'
+grafana_image_version: 'latest'
+grafana_port: '3000'
+grafana_password: 'super_secure_password'
+
+prometheus_port: '9090'
+
+provision_state: "started"

--- a/grafana/generic/setup-grafana/tasks/docker.yml
+++ b/grafana/generic/setup-grafana/tasks/docker.yml
@@ -1,0 +1,28 @@
+---
+- name: Run the datasources.yml template
+  template:
+    src: datasources.yml.j2
+    dest: /home/centos/datasources.yml
+    mode: 0755
+    owner: centos
+    group: centos
+
+- name: Run the dashboard.yml template
+  template:
+    src: dashboard.yml.j2
+    dest: /home/centos/dashboard.yml
+    mode: 0755
+    owner: centos
+    group: centos
+
+- name: Run the Grafana Docker container
+  docker_container:
+    name: grafana
+    image: "{{ grafana_image }}:{{ grafana_image_version }}"
+    published_ports:
+    - "{{ grafana_port }}:3000"
+    volumes:
+    - /home/centos/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:Z
+    env:
+      GF_SECURITY_ADMIN_PASSWORD: "{{ grafana_password }}"
+    state: "{{ provision_state }}"

--- a/grafana/generic/setup-grafana/tasks/main.yml
+++ b/grafana/generic/setup-grafana/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Run prereqs
+  import_tasks: prereqs.yml
+
+- name: Run the docker images
+  import_tasks: docker.yml

--- a/grafana/generic/setup-grafana/tasks/prereqs.yml
+++ b/grafana/generic/setup-grafana/tasks/prereqs.yml
@@ -1,0 +1,19 @@
+---
+- name: Ensure epel-release is installed
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - epel-release
+
+- name: Ensure pip is installed
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - python-pip
+
+- name: Install required python libraries
+  pip:
+    name: "docker-py"
+    state: present

--- a/grafana/generic/setup-grafana/templates/datasources.yml.j2
+++ b/grafana/generic/setup-grafana/templates/datasources.yml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: "http://{{ ansible_host }}:{{ prometheus_port }}"
+  jsonData:
+    tlsSkipVerify: true
+  editable: true

--- a/playbooks/infra-prometheus/inventory/group_vars/all.yml
+++ b/playbooks/infra-prometheus/inventory/group_vars/all.yml
@@ -1,0 +1,3 @@
+---
+docker_install: True
+docker_username: centos

--- a/playbooks/infra-prometheus/inventory/hosts
+++ b/playbooks/infra-prometheus/inventory/hosts
@@ -1,0 +1,11 @@
+[prometheus_master]
+
+[prometheus_node]
+
+[osp_instances:children]
+prometheus_master
+prometheus_node
+
+[prometheus]
+prometheus_master
+prometheus_node

--- a/playbooks/infra-prometheus/inventory/hosts
+++ b/playbooks/infra-prometheus/inventory/hosts
@@ -6,6 +6,6 @@
 prometheus_master
 prometheus_node
 
-[prometheus]
+[prometheus:children]
 prometheus_master
 prometheus_node

--- a/playbooks/infra-prometheus/inventory/openstack.py
+++ b/playbooks/infra-prometheus/inventory/openstack.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2012, Marco Vito Moscaritolo <marco@agavee.com>
+# Copyright (c) 2013, Jesse Keating <jesse.keating@rackspace.com>
+# Copyright (c) 2015, Hewlett-Packard Development Company, L.P.
+# Copyright (c) 2016, Rackspace Australia
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+# The OpenStack Inventory module uses os-client-config for configuration.
+# https://github.com/stackforge/os-client-config
+# This means it will either:
+#  - Respect normal OS_* environment variables like other OpenStack tools
+#  - Read values from a clouds.yaml file.
+# If you want to configure via clouds.yaml, you can put the file in:
+#  - Current directory
+#  - ~/.config/openstack/clouds.yaml
+#  - /etc/openstack/clouds.yaml
+#  - /etc/ansible/openstack.yml
+# The clouds.yaml file can contain entries for multiple clouds and multiple
+# regions of those clouds. If it does, this inventory module will connect to
+# all of them and present them as one contiguous inventory.
+#
+# See the adjacent openstack.yml file for an example config file
+# There are two ansible inventory specific options that can be set in
+# the inventory section.
+# expand_hostvars controls whether or not the inventory will make extra API
+#                 calls to fill out additional information about each server
+# use_hostnames changes the behavior from registering every host with its UUID
+#               and making a group of its hostname to only doing this if the
+#               hostname in question has more than one server
+# fail_on_errors causes the inventory to fail and return no hosts if one cloud
+#                has failed (for example, bad credentials or being offline).
+#                When set to False, the inventory will return hosts from
+#                whichever other clouds it can contact. (Default: True)
+
+import argparse
+import collections
+import os
+import sys
+import time
+from distutils.version import StrictVersion
+
+try:
+    import json
+except:
+    import simplejson as json
+
+import os_client_config
+import shade
+import shade.inventory
+
+CONFIG_FILES = ['/etc/ansible/openstack.yaml', '/etc/ansible/openstack.yml']
+
+
+def get_groups_from_server(server_vars, namegroup=True):
+    groups = []
+
+    region = server_vars['region']
+    cloud = server_vars['cloud']
+    metadata = server_vars.get('metadata', {})
+
+    # Create a group for the cloud
+    groups.append(cloud)
+
+    # Create a group on region
+    groups.append(region)
+
+    # And one by cloud_region
+    groups.append("%s_%s" % (cloud, region))
+
+    # Check if group metadata key in servers' metadata
+    if 'group' in metadata:
+        groups.append(metadata['group'])
+
+    for extra_group in metadata.get('groups', '').split(','):
+        if extra_group:
+            groups.append(extra_group.strip())
+
+    groups.append('instance-%s' % server_vars['id'])
+    if namegroup:
+        groups.append(server_vars['name'])
+
+    for key in ('flavor', 'image'):
+        if 'name' in server_vars[key]:
+            groups.append('%s-%s' % (key, server_vars[key]['name']))
+
+    for key, value in iter(metadata.items()):
+        groups.append('meta-%s_%s' % (key, value))
+
+    az = server_vars.get('az', None)
+    if az:
+        # Make groups for az, region_az and cloud_region_az
+        groups.append(az)
+        groups.append('%s_%s' % (region, az))
+        groups.append('%s_%s_%s' % (cloud, region, az))
+    return groups
+
+
+def get_host_groups(inventory, refresh=False):
+    (cache_file, cache_expiration_time) = get_cache_settings()
+    if is_cache_stale(cache_file, cache_expiration_time, refresh=refresh):
+        groups = to_json(get_host_groups_from_cloud(inventory))
+        open(cache_file, 'w').write(groups)
+    else:
+        groups = open(cache_file, 'r').read()
+    return groups
+
+
+def append_hostvars(hostvars, groups, key, server, namegroup=False):
+    hostvars[key] = dict(
+        ansible_ssh_host=server['interface_ip'],
+        openshift_hostname=server['name'],
+        openshift_public_hostname=server['name'],
+        openstack=server)
+    for group in get_groups_from_server(server, namegroup=namegroup):
+        groups[group].append(key)
+
+
+def get_host_groups_from_cloud(inventory):
+    groups = collections.defaultdict(list)
+    firstpass = collections.defaultdict(list)
+    hostvars = {}
+    list_args = {}
+    if hasattr(inventory, 'extra_config'):
+        use_hostnames = inventory.extra_config['use_hostnames']
+        list_args['expand'] = inventory.extra_config['expand_hostvars']
+        if StrictVersion(shade.__version__) >= StrictVersion("1.6.0"):
+            list_args['fail_on_cloud_config'] = \
+                inventory.extra_config['fail_on_errors']
+    else:
+        use_hostnames = False
+
+    for server in inventory.list_hosts(**list_args):
+
+        if 'interface_ip' not in server:
+            continue
+        try:
+          if server["metadata"][os.environ['OS_INV_FILTER_KEY']] == os.environ['OS_INV_FILTER_VALUE']:
+            firstpass[server['name']].append(server)
+        except:
+          firstpass[server['name']].append(server)
+    for name, servers in firstpass.items():
+        if len(servers) == 1 and use_hostnames:
+            append_hostvars(hostvars, groups, name, servers[0])
+        else:
+            server_ids = set()
+            # Trap for duplicate results
+            for server in servers:
+                server_ids.add(server['id'])
+            if len(server_ids) == 1 and use_hostnames:
+                append_hostvars(hostvars, groups, name, servers[0])
+            else:
+                for server in servers:
+                    append_hostvars(
+                        hostvars, groups, server['id'], server,
+                        namegroup=True)
+    groups['_meta'] = {'hostvars': hostvars}
+    return groups
+
+
+def is_cache_stale(cache_file, cache_expiration_time, refresh=False):
+    ''' Determines if cache file has expired, or if it is still valid '''
+    if refresh:
+        return True
+    if os.path.isfile(cache_file) and os.path.getsize(cache_file) > 0:
+        mod_time = os.path.getmtime(cache_file)
+        current_time = time.time()
+        if (mod_time + cache_expiration_time) > current_time:
+            return False
+    return True
+
+
+def get_cache_settings():
+    config = os_client_config.config.OpenStackConfig(
+        config_files=os_client_config.config.CONFIG_FILES + CONFIG_FILES)
+    # For inventory-wide caching
+    cache_expiration_time = config.get_cache_expiration_time()
+    cache_path = config.get_cache_path()
+    if not os.path.exists(cache_path):
+        os.makedirs(cache_path)
+    cache_file = os.path.join(cache_path, 'ansible-inventory.cache')
+    return (cache_file, cache_expiration_time)
+
+
+def to_json(in_dict):
+    return json.dumps(in_dict, sort_keys=True, indent=2)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='OpenStack Inventory Module')
+    parser.add_argument('--private',
+                        action='store_true',
+                        help='Use private address for ansible host')
+    parser.add_argument('--refresh', action='store_true',
+                        help='Refresh cached information')
+    parser.add_argument('--debug', action='store_true', default=False,
+                        help='Enable debug output')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--list', action='store_true',
+                       help='List active servers')
+    group.add_argument('--host', help='List details about the specific host')
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        config_files = os_client_config.config.CONFIG_FILES + CONFIG_FILES
+        shade.simple_logging(debug=args.debug)
+        inventory_args = dict(
+            refresh=args.refresh,
+            config_files=config_files,
+            private=args.private,
+        )
+        if hasattr(shade.inventory.OpenStackInventory, 'extra_config'):
+            inventory_args.update(dict(
+                config_key='ansible',
+                config_defaults={
+                    'use_hostnames': False,
+                    'expand_hostvars': True,
+                    'fail_on_errors': True,
+                }
+            ))
+
+        inventory = shade.inventory.OpenStackInventory(**inventory_args)
+
+        if args.list:
+            output = get_host_groups(inventory, refresh=args.refresh)
+        elif args.host:
+            output = to_json(inventory.get_host(args.host))
+        print(output)
+    except shade.OpenStackCloudException as e:
+        sys.stderr.write('%s\n' % e.message)
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/playbooks/infra-prometheus/remove-prometheus-grafana.yml
+++ b/playbooks/infra-prometheus/remove-prometheus-grafana.yml
@@ -11,7 +11,7 @@
   vars:
     provision_state: "absent"
   roles:
-    - monitoring/setup-node-exporter
+    - ../../prometheus/generic/setup-node-exporter
 
 - name: Setup prometheus
   hosts: prometheus_master
@@ -19,5 +19,5 @@
   vars:
     provision_state: "absent"
   roles:
-    - monitoring/setup-prometheus
-    - monitoring/setup-grafana
+    - ../../prometheus/generic/setup-prometheus
+    - ../../grafana/generic/setup-grafana

--- a/playbooks/infra-prometheus/remove-prometheus-grafana.yml
+++ b/playbooks/infra-prometheus/remove-prometheus-grafana.yml
@@ -1,0 +1,23 @@
+---
+- name: Install Docker
+  hosts: prometheus
+  become: True
+  roles:
+    - config-docker
+
+- name: Setup node exporters
+  hosts: prometheus_node
+  become: True
+  vars:
+    provision_state: "absent"
+  roles:
+    - monitoring/setup-node-exporter
+
+- name: Setup prometheus
+  hosts: prometheus_master
+  become: True
+  vars:
+    provision_state: "absent"
+  roles:
+    - monitoring/setup-prometheus
+    - monitoring/setup-grafana

--- a/playbooks/infra-prometheus/remove-prometheus-grafana.yml
+++ b/playbooks/infra-prometheus/remove-prometheus-grafana.yml
@@ -3,7 +3,7 @@
   hosts: prometheus
   become: True
   roles:
-    - config-docker
+    - infra-ansible/roles/config-docker
 
 - name: Setup node exporters
   hosts: prometheus_node

--- a/playbooks/infra-prometheus/requirements.yml
+++ b/playbooks/infra-prometheus/requirements.yml
@@ -1,0 +1,1 @@
+- src: https://github.com/redhat-cop/infra-ansible

--- a/playbooks/infra-prometheus/setup-prometheus-grafana.yml
+++ b/playbooks/infra-prometheus/setup-prometheus-grafana.yml
@@ -1,0 +1,23 @@
+---
+- name: Install Docker
+  hosts: prometheus
+  become: True
+  roles:
+    - config-docker
+
+- name: Setup node exporters
+  hosts: prometheus_node
+  become: True
+  vars:
+    provision_state: "started"
+  roles:
+    - ../../prometheus/generic/setup-node-exporter
+
+- name: Setup prometheus
+  hosts: prometheus_master
+  become: True
+  vars:
+    provision_state: "started"
+  roles:
+    - ../../prometheus/generic/setup-prometheus
+    - ../../grafana/generic/setup-grafana

--- a/playbooks/infra-prometheus/setup-prometheus-grafana.yml
+++ b/playbooks/infra-prometheus/setup-prometheus-grafana.yml
@@ -3,7 +3,7 @@
   hosts: prometheus
   become: True
   roles:
-    - config-docker
+    - infra-ansible/roles/config-docker
 
 - name: Setup node exporters
   hosts: prometheus_node

--- a/prometheus/generic/setup-node-exporter/README.md
+++ b/prometheus/generic/setup-node-exporter/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/prometheus/generic/setup-node-exporter/README.md
+++ b/prometheus/generic/setup-node-exporter/README.md
@@ -1,38 +1,50 @@
-Role Name
+setup-node-exporter
 =========
 
-A brief description of the role goes here.
+This role will instantiate a node-exporter container on targeted hosts.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+Docker must be available and running on the targeted hosts.
 
 Role Variables
 --------------
+Default values of variables:
+```
+node_exporter_image: 'prom/node-exporter'
+node_exporter_image_version: 'latest'
+node_exporter_port: '9100'
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+provision_state: "started"
+```
+`node_exporter_image` - The node exporter image to deploy.
+`node_exporter_image_version` - The image tag to deploy.
+`node_exporter_port` - The port to expose on the target hosts.
+`provision_state` - Options: [absent, killed, present, reloaded, restarted, **started** (default), stopped]
+
 
 Dependencies
 ------------
-
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+```
+python >= 2.6
+docker-py >= 0.3.0
+The docker server >= 0.10.0
+```
 
 Example Playbook
 ----------------
-
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+```
+- name: Setup node exporters
+  hosts: prometheus_nodes
+  become: True
+  vars:
+    provision_state: "started"
+  roles:
+    - prometheus/generic/setup-node-exporter
+```
 
 License
 -------
 
 BSD
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/prometheus/generic/setup-node-exporter/defaults/main.yml
+++ b/prometheus/generic/setup-node-exporter/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+node_exporter_image: 'prom/node-exporter'
+node_exporter_image_version: 'latest'
+node_exporter_port: '9100'
+
+provision_state: "started"

--- a/prometheus/generic/setup-node-exporter/tasks/docker.yml
+++ b/prometheus/generic/setup-node-exporter/tasks/docker.yml
@@ -1,0 +1,10 @@
+---
+- name: Run the node_exporter
+  docker_container:
+    name: node_exporter
+    image: "{{ node_exporter_image }}:{{ node_exporter_image_version }}"
+    pid_mode: "host"
+    network_mode: "host"
+    state: "{{ provision_state }}"
+    published_ports:
+    - "{{ node_exporter_port }}:9100"

--- a/prometheus/generic/setup-node-exporter/tasks/main.yml
+++ b/prometheus/generic/setup-node-exporter/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Run prereqs
+  import_tasks: prereqs.yml
+
+- name: Run the docker images
+  import_tasks: docker.yml

--- a/prometheus/generic/setup-node-exporter/tasks/prereqs.yml
+++ b/prometheus/generic/setup-node-exporter/tasks/prereqs.yml
@@ -1,0 +1,19 @@
+---
+- name: Ensure epel-release is installed
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - epel-release
+
+- name: Ensure pip is installed
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - python-pip
+
+- name: Install required python libraries
+  pip:
+    name: "docker-py"
+    state: present

--- a/prometheus/generic/setup-prometheus/README.md
+++ b/prometheus/generic/setup-prometheus/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/prometheus/generic/setup-prometheus/README.md
+++ b/prometheus/generic/setup-prometheus/README.md
@@ -1,38 +1,50 @@
-Role Name
+setup-node-exporter
 =========
 
-A brief description of the role goes here.
+This role will instantiate a prometheus container on targeted hosts.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+Docker must be available and running on the targeted hosts.
 
 Role Variables
 --------------
+Default values of variables:
+```
+prometheus_image: 'prom/prometheus'
+prometheus_image_version: 'latest'
+prometheus_port: '9090'
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+provision_state: "started"
+```
+`prometheus_image` - The node exporter image to deploy.
+`prometheus_image_version` - The image tag to deploy.
+`prometheus_port` - The port to expose on the target hosts.
+`provision_state` - Options: [absent, killed, present, reloaded, restarted, **started** (default), stopped]
+
 
 Dependencies
 ------------
-
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+```
+python >= 2.6
+docker-py >= 0.3.0
+The docker server >= 0.10.0
+```
 
 Example Playbook
 ----------------
-
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+```
+- name: Setup prometheus
+  hosts: prometheus_master
+  become: True
+  vars:
+    provision_state: "started"
+  roles:
+    - prometheus/generic/setup-prometheus
+```
 
 License
 -------
 
 BSD
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/prometheus/generic/setup-prometheus/defaults/main.yml
+++ b/prometheus/generic/setup-prometheus/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+prometheus_image: 'prom/prometheus'
+prometheus_image_version: 'latest'
+prometheus_port: '9090'
+
+provision_state: "started"

--- a/prometheus/generic/setup-prometheus/tasks/docker.yml
+++ b/prometheus/generic/setup-prometheus/tasks/docker.yml
@@ -1,0 +1,20 @@
+---
+- name: Run the prometheus.yml template
+  template:
+    src: prometheus.yml.j2
+    dest: /home/centos/prometheus.yml
+    mode: 0755
+    owner: centos
+    group: centos
+  vars:
+    target_nodes: "{{ groups['prom_node'] }}"
+
+- name: Run Prometheus Docker container
+  docker_container:
+    name: prometheus
+    image: "{{ prometheus_image }}:{{ prometheus_image_version }}"
+    published_ports:
+    - "{{ prometheus_port }}:9090"
+    volumes:
+    - /home/centos/prometheus.yml:/etc/prometheus/prometheus.yml:Z
+    state: "{{ provision_state }}"

--- a/prometheus/generic/setup-prometheus/tasks/docker.yml
+++ b/prometheus/generic/setup-prometheus/tasks/docker.yml
@@ -7,7 +7,7 @@
     owner: centos
     group: centos
   vars:
-    target_nodes: "{{ groups['prom_node'] }}"
+    target_nodes: "{{ groups['prometheus_node'] }}"
 
 - name: Run Prometheus Docker container
   docker_container:

--- a/prometheus/generic/setup-prometheus/tasks/main.yml
+++ b/prometheus/generic/setup-prometheus/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Run prereqs
+  import_tasks: prereqs.yml
+
+- name: Run the docker images
+  import_tasks: docker.yml

--- a/prometheus/generic/setup-prometheus/tasks/prereqs.yml
+++ b/prometheus/generic/setup-prometheus/tasks/prereqs.yml
@@ -1,0 +1,19 @@
+---
+- name: Ensure epel-release is installed
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - epel-release
+
+- name: Ensure pip is installed
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - python-pip
+
+- name: Install required python libraries
+  pip:
+    name: "docker-py"
+    state: present

--- a/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
+++ b/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
@@ -1,0 +1,25 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'codelab-monitor'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'node_exporter'
+    scrape_interval: 5s
+    static_configs:
+      {% for host in target_nodes %}
+      - targets: ['{{ hostvars[host].ansible_ssh_host }}:9100']
+              labels:
+                host: '{{ host }}'
+                job: 'node'
+      {% endfor %}


### PR DESCRIPTION
This PR adds some generic roles for spinning up containers for prometheus, node exporter, and grafana. Included is a playbook which spins up all 3 and connects them.

Also included is a proposed structure for directory organization.

### How to test
In the playbooks directory there is a sub-directory for prometheus+grafana which has a provision and deletion playbook and an included inventory. The hosts file should be updated by adding desired hosts to the prometheus_master and prometheus_node groups.