### PR TITLE
Updating 'openshift-applier' version

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# How to Contribute
+
+We welcome contributions from the community. Here are a few ways you can help us improve.
+
+## Open an Issue
+
+If you see something you'd like changed, but aren't sure how to change it, submit an issue describing what you'd like to see.
+
+## Submit a Pull Request
+
+If you feel like getting your hands dirty, feel free to make the change yourself. Here's how:
+
+1. Fork the repo on Github, and then clone it locally.
+2. Create a branch named appropriately for the change you are going to make.
+3. Make your code change.
+4. Push your code change up to your forked repo.
+5. Open a Pull Request to merge your changes to this repo. The comment box will be filled in automatically via a template.
+
+See [Using Pull Requests](https://help.github.com/articles/using-pull-requests/) got more information on how to use GitHub PRs.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### What does this PR do?
+Brief explanation of the code or documentation change you've made
+
+### How should this be tested?
+Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)
+
+### Is there a relevant Issue open for this?
+Provide a link to any open issues that describe the problem you are solving.
+resolves #<number>
+
+### Other Relevant info, PRs, etc.
+Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
+
+### People to notify
+cc: @redhat-cop/monitoring

--- a/prometheus/openshift/inventory/host_vars/localhost.yml
+++ b/prometheus/openshift/inventory/host_vars/localhost.yml
@@ -1,0 +1,3 @@
+---
+
+ansible_connection: local

--- a/prometheus/openshift/inventory/hosts
+++ b/prometheus/openshift/inventory/hosts
@@ -1,2 +1,3 @@
+
 [seed-hosts]
-localhost ansible_connection=local
+localhost

--- a/prometheus/openshift/requirements.yml
+++ b/prometheus/openshift/requirements.yml
@@ -4,4 +4,4 @@
 - name: openshift-applier
   scm: git
   src: https://github.com/redhat-cop/openshift-applier.git
-  version: v3.7.2
+  version: v1.0.2


### PR DESCRIPTION
### What does this PR do?
- Updating the `openshift-applier` version to the latest `v1.0.x` release per messaging about deprecating the v3.x versions. 
- Added the GitHub template files for PR and contributions.

### How should this be tested?
Run the inventory in the `prometheus/openshift/` area to validate that the `openshift-applier` works as expected.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
Updating content delivered by PR #1 

### People to notify
cc: @redhat-cop/monitoring @tylerauerbeck @logandonley 
