### PR TITLE
Federate prometheus cluster

### DIFF
--- a/grafana/generic/setup-grafana/tasks/docker.yml
+++ b/grafana/generic/setup-grafana/tasks/docker.yml
@@ -26,3 +26,4 @@
     env:
       GF_SECURITY_ADMIN_PASSWORD: "{{ grafana_password }}"
     state: "{{ provision_state }}"
+    restart: yes

--- a/prometheus/generic/setup-prometheus/tasks/docker.yml
+++ b/prometheus/generic/setup-prometheus/tasks/docker.yml
@@ -18,3 +18,4 @@
     volumes:
     - /home/centos/prometheus.yml:/etc/prometheus/prometheus.yml:Z
     state: "{{ provision_state }}"
+    restart: yes

--- a/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
+++ b/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
@@ -4,11 +4,29 @@ global:
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).
   external_labels:
-    monitor: 'codelab-monitor'
+    monitor: 'codelab-monitor-{{hostvars[inventory_hostname].ansible_ssh_host}}'
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
+{% if (groups['prometheus_master'] |length ) > 1 %}
+  - job_name: 'federate-sanity-check'
+    scrape_interval: 15s
+
+    honor_labels: true
+    metrics_path: '/federate'
+
+    params:
+      'match[]':
+        - '{job=~"prometheus"}'
+
+    static_configs:
+{% for host in groups['prometheus_master'] %}
+{% if hostvars[host].ansible_host != ansible_host %}
+      - targets: ['{{hostvars[host].ansible_host}}:9090']
+{% endif %}   
+{% endfor %}
+{% endif %}
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'prometheus'
     scrape_interval: 5s

--- a/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
+++ b/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
@@ -13,7 +13,6 @@ scrape_configs:
   - job_name: 'federate-sanity-check'
     scrape_interval: 15s
 
-    honor_labels: true
     metrics_path: '/federate'
 
     params:


### PR DESCRIPTION
### What does this PR do?
Adds cross-master federation

### How should this be tested?
Run the automation with 2 prometheus master nodes. After successfull run the prometheus will scrape remaining prometheus master's federate endpoint and match timeseries job=prometheus, which can be verified in prometheus. 

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/monitoring
