### PR TITLE
Grafana datasource

### DIFF
--- a/grafana/generic/configure-grafana-datasource/README.md
+++ b/grafana/generic/configure-grafana-datasource/README.md
@@ -1,0 +1,58 @@
+setup-node-exporter
+=========
+
+This role will instantiate a grafana container on targeted hosts. It also seeds the host with dashboards
+
+Requirements
+------------
+
+Docker must be available and running on the targeted hosts.
+
+Role Variables
+--------------
+Default values of variables:
+```
+---
+grafana_image: 'grafana/grafana'
+grafana_image_version: 'latest'
+grafana_port: '3000'
+grafana_password: 'super_secure_password'
+
+prometheus_port: '9090'
+
+provision_state: "started"
+
+```
+`grafana_image` - The node exporter image to deploy.
+`grafana_image_version` - The image tag to deploy.
+`grafana_port` - The port to expose on the target hosts.
+`grafana_password` - The admin password to set for Grafana.
+`prometheus_port` - The target port on the prometheus host to pull data.
+`provision_state` - Options: [absent, killed, present, reloaded, restarted, **started** (default), stopped]
+
+
+Dependencies
+------------
+```
+python >= 2.6
+docker-py >= 0.3.0
+The docker server >= 0.10.0
+```
+
+Example Playbook
+----------------
+```
+- name: Setup grafana
+  hosts: grafana
+  become: True
+  vars:
+    provision_state: "started"
+    dashboard_dir: "/home/user/dashboards"
+  roles:
+    - grafana/generic/setup-grafana
+```
+
+License
+-------
+
+BSD

--- a/grafana/generic/configure-grafana-datasource/README.md
+++ b/grafana/generic/configure-grafana-datasource/README.md
@@ -1,55 +1,58 @@
-setup-node-exporter
+setup-grafana-datasource
 =========
 
-This role will instantiate a grafana container on targeted hosts. It also seeds the host with dashboards
+This role will configures Openshift operated prometheus datasources. It iterates over "{{ datasources }}" list described in Example Inventory section.
 
 Requirements
 ------------
 
-Docker must be available and running on the targeted hosts.
+grafana has to be running on target host
 
 Role Variables
 --------------
 Default values of variables:
 ```
 ---
-grafana_image: 'grafana/grafana'
-grafana_image_version: 'latest'
 grafana_port: '3000'
 grafana_password: 'super_secure_password'
 
-prometheus_port: '9090'
+```
+`grafana_port:` - port on which grafana is listening
+`grafana_password:` - password for grafana admin user
 
-provision_state: "started"
+Example Inventory
+-----------------
+```
+---
+datasources:
+- name: "test_datasource"
+  datasource_url: "https://prometheus-k8s-openshift-monitoring.apps.openshift.test.com"
+  bearer_token:
 
 ```
-`grafana_image` - The node exporter image to deploy.
-`grafana_image_version` - The image tag to deploy.
-`grafana_port` - The port to expose on the target hosts.
-`grafana_password` - The admin password to set for Grafana.
-`prometheus_port` - The target port on the prometheus host to pull data.
-`provision_state` - Options: [absent, killed, present, reloaded, restarted, **started** (default), stopped]
+datasources:
+- name: - name of new datasource
+  datasource_url: - url on which the prometheus is listening
+  bearer_token: - authentication token for the Prometheus Oauth proxy
 
 
 Dependencies
 ------------
 ```
 python >= 2.6
-docker-py >= 0.3.0
-The docker server >= 0.10.0
 ```
 
 Example Playbook
 ----------------
 ```
-- name: Setup grafana
+- name: Setup grafana datasourdce
   hosts: grafana
   become: True
   vars:
-    provision_state: "started"
-    dashboard_dir: "/home/user/dashboards"
+    grafana_port: '3000'
+    grafana_password: 'custom_password'
   roles:
-    - grafana/generic/setup-grafana
+    - grafana/generic/configure-grafana-datasource
 ```
 
 License

--- a/grafana/generic/configure-grafana-datasource/README.md
+++ b/grafana/generic/configure-grafana-datasource/README.md
@@ -1,12 +1,12 @@
 setup-grafana-datasource
-=========
+========================
 
-This role will configures Openshift operated prometheus datasources. It iterates over "{{ datasources }}" list described in Example Inventory section.
+This role will configure Openshift operated prometheus datasources. It iterates over "{{ datasources }}" list described in Example Inventory section.
 
 Requirements
 ------------
 
-grafana has to be running on target host
+Grafana has to be running on target host
 
 Role Variables
 --------------
@@ -15,10 +15,12 @@ Default values of variables:
 ---
 grafana_port: '3000'
 grafana_password: 'super_secure_password'
+grafana_user: 'admin' 
 
 ```
 `grafana_port:` - port on which grafana is listening
-`grafana_password:` - password for grafana admin user
+`grafana_password:` - password for grafana
+`grafana_user:` - user in grafana who can create datasource
 
 Example Inventory
 -----------------
@@ -46,11 +48,12 @@ Example Playbook
 ----------------
 ```
 - name: Setup grafana datasourdce
-  hosts: grafana
+  hosts: prometheus_scraper
   become: True
   vars:
     grafana_port: '3000'
     grafana_password: 'custom_password'
+    grafana_user: 'custom_user'
   roles:
     - grafana/generic/configure-grafana-datasource
 ```

--- a/grafana/generic/configure-grafana-datasource/defaults/main.yml
+++ b/grafana/generic/configure-grafana-datasource/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+grafana_port: '3000'
+grafana_password: 'super_secure_password'

--- a/grafana/generic/configure-grafana-datasource/defaults/main.yml
+++ b/grafana/generic/configure-grafana-datasource/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 grafana_port: '3000'
 grafana_password: 'super_secure_password'
+grafana_user: 'admin'

--- a/grafana/generic/configure-grafana-datasource/files/datasource.json
+++ b/grafana/generic/configure-grafana-datasource/files/datasource.json
@@ -1,7 +1,0 @@
-{
-  "name":"test_datasource",
-  "type":"graphite",
-  "url":"{{ datasource }}",
-  "access":"proxy",
-  "basicAuth":false
-}

--- a/grafana/generic/configure-grafana-datasource/files/datasource.json
+++ b/grafana/generic/configure-grafana-datasource/files/datasource.json
@@ -1,0 +1,7 @@
+{
+  "name":"test_datasource",
+  "type":"graphite",
+  "url":"{{ datasource }}",
+  "access":"proxy",
+  "basicAuth":false
+}

--- a/grafana/generic/configure-grafana-datasource/tasks/main.yml
+++ b/grafana/generic/configure-grafana-datasource/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- debug:
+    var: datasources
+
+- name: create datasource
+  uri:
+    url: "http://{{ ansible_host }}:{{ grafana_port }}/api/datasources"
+    method: POST
+    body: "{{ lookup ('template', 'datasource.json.j2') | to_json }}"
+    body_format: json
+    url_username: admin
+    url_password: "{{ grafana_password }}"
+    force_basic_auth: true
+    headers:
+      Accept: "application/json"
+      Content-type: "application/json"
+  loop: "{{ datasources }}"

--- a/grafana/generic/configure-grafana-datasource/tasks/main.yml
+++ b/grafana/generic/configure-grafana-datasource/tasks/main.yml
@@ -1,14 +1,11 @@
 ---
-- debug:
-    var: datasources
-
 - name: create datasource
   uri:
     url: "http://{{ ansible_host }}:{{ grafana_port }}/api/datasources"
     method: POST
     body: "{{ lookup ('template', 'datasource.json.j2') | to_json }}"
     body_format: json
-    url_username: admin
+    url_username: "{{ grafana_user }}"
     url_password: "{{ grafana_password }}"
     force_basic_auth: true
     headers:

--- a/grafana/generic/configure-grafana-datasource/templates/datasource.json.j2
+++ b/grafana/generic/configure-grafana-datasource/templates/datasource.json.j2
@@ -1,0 +1,13 @@
+{
+  "name":"{{ item.name }}",
+  "type":"prometheus",
+  "url":"{{ item.datasource_url }}",
+  "access":"proxy",
+  "basicAuth":false,
+  "jsonData": {
+    "httpHeaderName1":"Authorization"
+  },
+  "securejsonData": {
+    "httpHeaderValue1":"Bearer {{ item.bearer_token }}"
+  }
+}

--- a/playbooks/infra-prometheus/inventory/group_vars/prometheus_scraper.yml
+++ b/playbooks/infra-prometheus/inventory/group_vars/prometheus_scraper.yml
@@ -4,3 +4,14 @@ smtp_port: my_smtp_port
 from: my_smtp_from
 smtp_username: 'smtp_user'
 smtp_password: 'smtp_password'
+smtp_tls: 'false'
+
+
+
+#Below is an example inventory for the setup-grafana-datasource.yml playbook
+#datasources:
+#- name: "openshift-1"
+#  datasource_url: "https://prometheus-k8s-openshift-monitoring.apps.openshift-1.example.com"
+#  bearer_token: "prometheus-k8s-secret-token"
+
+

--- a/playbooks/infra-prometheus/inventory/group_vars/prometheus_scraper.yml
+++ b/playbooks/infra-prometheus/inventory/group_vars/prometheus_scraper.yml
@@ -8,7 +8,7 @@ smtp_tls: 'false'
 
 
 
-#Below is an example inventory for the setup-grafana-datasource.yml playbook
+#Below is an example inventory for the configure-grafana-datasource role
 #datasources:
 #- name: "openshift-1"
 #  datasource_url: "https://prometheus-k8s-openshift-monitoring.apps.openshift-1.example.com"

--- a/playbooks/infra-prometheus/setup-grafana-datasource.yml
+++ b/playbooks/infra-prometheus/setup-grafana-datasource.yml
@@ -1,0 +1,7 @@
+---
+- name: setup datasource
+  hosts: prometheus_scraper
+  become: True
+  roles:
+    - ../../grafana/generic/configure-grafana-datasource
+#  delegate_to: localhost

--- a/playbooks/infra-prometheus/setup-grafana-datasource.yml
+++ b/playbooks/infra-prometheus/setup-grafana-datasource.yml
@@ -4,4 +4,3 @@
   become: True
   roles:
     - ../../grafana/generic/configure-grafana-datasource
-#  delegate_to: localhost

--- a/playbooks/infra-prometheus/setup-grafana-datasource.yml
+++ b/playbooks/infra-prometheus/setup-grafana-datasource.yml
@@ -2,5 +2,9 @@
 - name: setup datasource
   hosts: prometheus_scraper
   become: True
+  vars:
+    grafana_port: '3000'
+    grafana_password: 'custom_password'
+    grafana_user: 'custom_admin'
   roles:
     - ../../grafana/generic/configure-grafana-datasource


### PR DESCRIPTION
### What does this PR do?
Add role which configures OCP operated prometheus as a datasource to grafana

### How should this be tested?
Run the playbooks/infra-prometheus/setup-prometheus-grafana.yml playbook.

The role loops over "{{ datasources }}". Example inventory below.
```
datasources:
- name: "openshift-1"
  datasource_url: "https://prometheus-k8s-openshift-monitoring.apps.openshift-1.example.com"
  bearer_token: "prometheus-k8s-secret-token"`
```

Other configurable variables, below are the default values. 
```
grafana_port: '3000'
grafana_password: 'super_secure_password'
grafana_user: 'admin'
```

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/monitoring

