### PR TITLE
Add template for ssl_exporter targets in prometheus.yml.j2

### DIFF
--- a/prometheus/generic/setup-prometheus/README.md
+++ b/prometheus/generic/setup-prometheus/README.md
@@ -30,6 +30,16 @@ provision_state: "started"
 
 `provision_state` - Options: [absent, killed, present, reloaded, restarted, **started** (default), stopped]
 
+Example Inventory
+-----------------
+
+Snippet below configures targets for the SSL exporter. It was taken from group_vars/prometheus_scraper.yml. {{ ssl_certs }} has to be defined for hostgroup prometheus_scraper or all, because the values are used in prometheus.yml.j2 template on the scraper nodes.
+
+```
+ssl_certs:
+  - console-openshift-console.apps.openshift-1.example.com:443
+  - api.openshift-1.example.com:6443
+```
 
 Dependencies
 ------------

--- a/prometheus/generic/setup-prometheus/README.md
+++ b/prometheus/generic/setup-prometheus/README.md
@@ -15,12 +15,19 @@ Default values of variables:
 prometheus_image: 'prom/prometheus'
 prometheus_image_version: 'latest'
 prometheus_port: '9090'
+haproxy_exporter_port: '9101'
+bind_exporter_port: '9119'
+ssl_exporter_port: '9219'
 
 provision_state: "started"
 ```
 `prometheus_image` - The node exporter image to deploy.
 `prometheus_image_version` - The image tag to deploy.
 `prometheus_port` - The port to expose on the target hosts.
+`haproxy_exporter_port:` - default port on which ha_proxy exporter listens, used for prometheus.yml.j2 template
+`bind_exporter_port:` - default port on which bind exporter listens, used for prometheus.yml.j2 template
+`ssl_exporter_port:` - default port on which ssl exporter listens, used for prometheus.yml.j2 templat
+
 `provision_state` - Options: [absent, killed, present, reloaded, restarted, **started** (default), stopped]
 
 

--- a/prometheus/generic/setup-prometheus/defaults/main.yml
+++ b/prometheus/generic/setup-prometheus/defaults/main.yml
@@ -4,5 +4,6 @@ prometheus_image_version: 'latest'
 prometheus_port: '9090'
 haproxy_exporter_port: '9101'
 bind_exporter_port: '9119'
+ssl_exporter_port: '9219'
 
 provision_state: "started"

--- a/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
+++ b/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
@@ -77,3 +77,21 @@ scrape_configs:
 {% endfor %}
 {% endif %}
 
+{% if ssl_certs is defined %}
+  - job_name: 'ssl'
+    metrics_path: /probe
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+{% for cert in ssl_certs %}
+          - {{ cert }}
+{% endfor %}
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:{{ ssl_exporter_port }}
+{% endif %}
+

--- a/prometheus/generic/setup-ssl-exporter/README.md
+++ b/prometheus/generic/setup-ssl-exporter/README.md
@@ -26,11 +26,11 @@ provision_state: "started"
 Example Inventory
 -----------------
 
-Section below configures targets for the SSL exporter. {{ ssl_certs }} variable has to be defined for hostgroup prometheus_scraper or all, because the values are used in prometheus.yml.j2 template on the scrapers.
+Snippet below configures targets for the SSL exporter. It was taken from group_vars/prometheus_scraper.yml. {{ ssl_certs }} has to be defined for hostgroup prometheus_scraper or all, because the values are used in prometheus.yml.j2 template on the scraper nodes.
 
 ssl_certs:
-  - https://console-openshift-console.apps.openshift-1.example.com:443
-  - https://api.openshift-1.example.com:6443
+  - console-openshift-console.apps.openshift-1.example.com:443
+  - api.openshift-1.example.com:6443
 
 
 

--- a/prometheus/generic/setup-ssl-exporter/README.md
+++ b/prometheus/generic/setup-ssl-exporter/README.md
@@ -23,6 +23,16 @@ provision_state: "started"
 `ssl_exporter_port` - The port to expose on the target hosts.
 `provision_state` - Options: [absent, killed, present, reloaded, restarted, **started** (default), stopped]
 
+Example Inventory
+-----------------
+
+Section below configures targets for the SSL exporter. {{ ssl_certs }} variable has to be defined for hostgroup prometheus_scraper or all, because the values are used in prometheus.yml.j2 template on the scrapers.
+
+ssl_certs:
+  - https://console-openshift-console.apps.openshift-1.example.com:443
+  - https://api.openshift-1.example.com:6443
+
+
 
 Dependencies
 ------------


### PR DESCRIPTION
### What does this PR do?
Add ssl_exporter target to prometheus.yml.j2 template

### How should this be tested?
run playbooks/infra-prometheus/setup-prometheus-grafana.yml playbook with following snippet in the inventory.
```
ssl_certs:
  - console-openshift-console.apps.openshift-1.example.com:443
  - api.openshift-1.example.com:6443
```
the generated  prometheus.yml file should contain following section
```
  - job_name: 'ssl'
    metrics_path: /probe
    scrape_interval: 5s
    static_configs:
      - targets:
          - console-openshift-console.openshift-1.example.com:443
          - api.openshift-1.example.com:6443
    relabel_configs:
      - source_labels: [__address__]
        target_label: __param_target
      - source_labels: [__param_target]
        target_label: instance
      - target_label: __address__
        replacement: 127.0.0.1:9219
```


### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/monitoring
