### PR TITLE
Add playbook for adding operated prometheus, fix error handling in configure-grafana-datasource

### DIFF
--- a/grafana/generic/configure-grafana-datasource/tasks/main.yml
+++ b/grafana/generic/configure-grafana-datasource/tasks/main.yml
@@ -12,3 +12,7 @@
       Accept: "application/json"
       Content-type: "application/json"
   loop: "{{ datasources }}"
+  register: result
+  failed_when: 
+    - '"already exists" not in result.json.message'
+    - result.status != 200

--- a/playbooks/infra-prometheus/add-ocp-cluster.yml
+++ b/playbooks/infra-prometheus/add-ocp-cluster.yml
@@ -1,0 +1,14 @@
+---
+- name: add datasource to grafana
+  hosts: prometheus_scraper
+  become: True
+  roles:
+    - ../../grafana/generic/configure-grafana-datasource
+
+- name: setup prometheus targets
+  hosts: prometheus_scraper
+  become: True
+  vars:
+    provision_state: started
+  roles:
+    - ../../prometheus/generic/setup-prometheus

--- a/prometheus/generic/setup-prometheus/defaults/main.yml
+++ b/prometheus/generic/setup-prometheus/defaults/main.yml
@@ -2,8 +2,10 @@
 prometheus_image: 'prom/prometheus'
 prometheus_image_version: 'latest'
 prometheus_port: '9090'
+alertmanager_port: '9093'
 haproxy_exporter_port: '9101'
 bind_exporter_port: '9119'
 ssl_exporter_port: '9219'
+
 
 provision_state: "started"

--- a/prometheus/generic/setup-prometheus/tasks/docker.yml
+++ b/prometheus/generic/setup-prometheus/tasks/docker.yml
@@ -19,6 +19,7 @@
   docker_container:
     name: prometheus
     image: "{{ prometheus_image }}:{{ prometheus_image_version }}"
+    network_mode: host
     published_ports:
     - "{{ prometheus_port }}:9090"
     volumes:

--- a/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
+++ b/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
@@ -34,21 +34,35 @@ scrape_configs:
         job: 'node'
 {% endfor %}
 
-
 {% if (groups['prometheus_scraper'] |length ) > 1 %}
   - job_name: 'federate-sanity-check'
     scrape_interval: 15s
-
     metrics_path: '/federate'
-
     params:
       'match[]':
         - '{job=~"prometheus"}'
-
     static_configs:
 {% for host in groups['prometheus_scraper'] %}
 {% if hostvars[host].ansible_host != ansible_host %}
       - targets: ['{{hostvars[host].ansible_host}}:9090']
+{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if datasources is defined %}
+  - job_name: 'federate-openshift-environment'
+    scrape_interval: 15s
+    metrics_path: '/metrics'
+    scheme: 'https'
+    params:
+      'match[]':
+        - '{job=~"prometheus"}'
+    static_configs:
+{% for ocp in datasources %}
+{% if ocp.datasource_url.startswith('https://') %}
+      - targets: ['{{ ocp.datasource_url[8:] }}']
+{% else %}
+      - targets: ['{{ ocp.datasource_url }}']
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
+++ b/prometheus/generic/setup-prometheus/templates/prometheus.yml.j2
@@ -13,7 +13,7 @@ alerting:
    - static_configs:
      - targets:
        # Alertmanager's default port is 9093
-       - "{{ ansible_host }}:9093"
+       - "127.0.0.1:{{ alertmanager_port }}"
 
 rule_files:
   - "first_rules.yml"


### PR DESCRIPTION
### What does this PR do?
Adds error handling to configure-grafana-datasource playbook. Now the task does fail only when the return code is not 200 and message  doesn't contain "already exists". This ensures that the role/playbooks will continue even when the datasource already exists in grafana
```
  register: result
  failed_when:
    - '"already exists" not in result.json.message'
    - result.status != 200
```

The PR also adds OCP operated prometheus as a scrape_target in the prometheus.yml template. The template iterates over "{{ datasources.datasource_url }}". Removes https:// prefix if needed and configures the prometheus-k8s url as a scraping target. The scraping is done through /metrics endpoint. Prometheus will trigger alert if the UP metric returns 0 (either the target is removed or prometheus-k8s stops responding)

```
datasources:
- name: "openshift-1"
  datasource_url: "https://prometheus-k8s-monitoring.apps.openshift-1.example.com"
  bearer_token: "my_secret_token"
```
Adds add-ocp-cluster.yml playbook which adds OCP cluster to monitoring. Sets up grafana datasource configures operated prometheus as a target and optionally can configure ssl exporter target. Example inventory below:

```
datasources:
- name: "openshift-1"
  datasource_url: "https://prometheus-k8s-monitoring.apps.openshift-1.example.com"
  bearer_token: "my_secret_token"

ssl_certs:
  - prometheus-k8s-monitoring.apps.openshift-1.example.com:443
  - api.openshift-1.example.com:6443
```



Change the network_mode: host on prometheus container

Make the alertmanager_port configurable defaults to 9093

### How should this be tested?
Run the add-ocp-cluster.yml playbook with correct "{{ datasources }}" list in the inventory

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/monitoring
