### PR TITLE
add openshift-playbook

### DIFF
--- a/files/ocp_alertmanager_templates/alertmanager.yaml.j2
+++ b/files/ocp_alertmanager_templates/alertmanager.yaml.j2
@@ -44,5 +44,5 @@ route:
       receiver: Critical
     - receiver: mail
       match_re:
-        severity: Warning|Critical
+        severity: warning|critical
 

--- a/files/ocp_alertmanager_templates/alertmanager.yaml.j2
+++ b/files/ocp_alertmanager_templates/alertmanager.yaml.j2
@@ -1,0 +1,48 @@
+global:
+  resolve_timeout: 5m
+inhibit_rules:
+  - equal:
+      - namespace
+      - alertname
+    source_match:
+      severity: critical
+    target_match_re:
+      severity: warning|info
+  - equal:
+      - namespace
+      - alertname
+    source_match:
+      severity: warning
+    target_match_re:
+      severity: info
+receivers:
+  - name: Critical
+  - name: Default
+  - name: Watchdog
+  - name: mail
+    email_configs:
+      - to: "{{ notification_recipients }}"
+        from: "{{ from }}"
+        smarthost: '{{ smtp_host }}:{{ smtp_port }}'
+        auth_username: "{{ smtp_username }}"
+        auth_password: "{{ smtp_password }}"
+        auth_identity: "{{ smtp_username }}"
+        require_tls: false
+route:
+  group_by:
+    - namespace
+  group_interval: 5m
+  group_wait: 30s
+  receiver: Default
+  repeat_interval: 12h
+  routes:
+    - match:
+        alertname: Watchdog
+      receiver: Watchdog
+    - match:
+        severity: critical
+      receiver: Critical
+    - receiver: mail
+      match_re:
+        severity: Warning|Critical
+

--- a/playbooks/infra-prometheus/monitoring-hosts/add-openshift.yml
+++ b/playbooks/infra-prometheus/monitoring-hosts/add-openshift.yml
@@ -1,0 +1,23 @@
+---
+- name: setup targets
+  gather_facts: no
+  hosts: monitoring-hosts
+  roles:
+    - ../../../prometheus/generic/add-target
+
+- name: setup datasource
+  hosts: monitoring-hosts
+  become: True
+  vars:
+    grafana_port: '3000'
+  roles:
+    - ../../../grafana/generic/configure-grafana-datasource
+
+- name: create alertmanager.yml
+  hosts: monitoring-hosts
+  tasks:
+  - template:
+      src: ../../../files/ocp_alertmanager_templates/alertmanager.yaml.j2
+      dest: ../../../files/ocp_alertmanager_templates/alertmanager.yaml
+    delegate_to: localhost
+


### PR DESCRIPTION
### What does this PR do?
adds playbook which configures integrates OCP with the monitoring.
adds ocp_alertmanager_template/alertmanager.yaml.j2 in files/ , This config file takes OCP-specific "Watchdog" alert into consideration
 
No functional improvement has been done. The add-openshift.yml runs add-targets  and configure-datasource roles + templates alertmanager.yaml.j2 and saves it to the files/ocp_alertmanager_template/alertmanager.yaml. The templated file should be then applied to alertmanager-main secret in OCP. 

### How should this be tested?


### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)

### People to notify
cc: @redhat-cop/monitoring
